### PR TITLE
Add clang extra tools

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -18,6 +18,12 @@
              path="hcc/clang"
              remote="github_hcc"
              revision="clang_tot_upgrade"/>
+    
+    <!-- ToT Clang extra tools -->
+    <project name="RadeonOpenCompute/clang-tools-extra"
+             path="clang/tools/extra"
+             remote="github_hcc"
+             revision="clang_tot_upgrade"/>
 
     <!-- amd-hcc LLVM placed inside ToT HCC -->
     <project name="RadeonOpenCompute/llvm"


### PR DESCRIPTION
This adds clang extra tool repo, which includes static analysis tools such as clang tidy. Building this with hcc allow these tools to be used with hcc-based projects.